### PR TITLE
feat: add auto-release workflow and Zabbix 7.2+ path compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,202 @@
+name: Release Zabbix Modules
+
+# 当任意模块的 manifest.json 中 version 字段升级并推送到主分支时，
+# 自动打包所有模块和整体项目到一个 Release 中。
+# 版本号格式：模块数量.大版本.小版本（如 8.1.0）
+# Release Assets 包含：
+#   - zabbix_modules-<版本号>.tar.gz（整体打包）
+#   - zabbix_<模块名>-<版本号>.tar.gz（每个模块独立打包）
+# 也支持手动触发。
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'zabbix_*/manifest.json'
+  workflow_dispatch:
+
+jobs:
+  detect-and-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed modules with version bump
+        id: detect
+        run: |
+          # Find all module directories
+          modules=()
+          for dir in zabbix_*/; do
+            [ -d "$dir" ] || continue
+            [ -f "${dir}manifest.json" ] || continue
+            modules+=("${dir%/}")
+          done
+
+          echo "Found modules: ${modules[*]}"
+
+          # Determine whether to release:
+          # - Manual trigger: always release
+          # - Push trigger: only when at least one module's version changed
+          should_release="false"
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            should_release="true"
+            echo "Manual trigger: will release"
+          else
+            for mod in "${modules[@]}"; do
+              mf="${mod}/manifest.json"
+              current_ver=$(python3 -c "import json; print(json.load(open('$mf'))['version'])")
+              prev_ver=$(git show HEAD~1:"${mf}" 2>/dev/null | python3 -c "import json,sys; print(json.load(sys.stdin)['version'])" 2>/dev/null || echo "")
+              if [ -z "$prev_ver" ] || [ "$current_ver" != "$prev_ver" ]; then
+                echo "  $mod: version changed (${prev_ver:-new} -> ${current_ver}), will release"
+                should_release="true"
+              else
+                echo "  $mod: version unchanged (${current_ver}), skip"
+              fi
+            done
+          fi
+
+          echo "should_release=${should_release}" >> $GITHUB_OUTPUT
+
+      - name: Package all modules and project into single Release
+        if: steps.detect.outputs.should_release == 'true'
+        run: |
+          # Count modules
+          MODULE_COUNT=$(ls -d zabbix_*/ 2>/dev/null | wc -l)
+          echo "Module count: ${MODULE_COUNT}"
+
+          # Find the latest major version for this module count
+          # Version format: {module_count}.{major}.{minor} (e.g., 8.1.0)
+          LATEST_MAJOR=0
+          for tag in $(git tag --list "v${MODULE_COUNT}.*"); do
+            major=$(echo "${tag}" | sed "s/v${MODULE_COUNT}\.\([0-9]*\)\.[0-9]*/\1/")
+            if [[ "${major}" =~ ^[0-9]+$ ]] && [ "${major}" -gt "${LATEST_MAJOR}" ] 2>/dev/null; then
+              LATEST_MAJOR="${major}"
+            fi
+          done
+
+          MAJOR_VER=$((LATEST_MAJOR + 1))
+          VERSION="${MODULE_COUNT}.${MAJOR_VER}.0"
+          echo "Release version: ${VERSION}"
+
+          tag="v${VERSION}"
+
+          # Check if tag already exists
+          if git rev-parse "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Tag ${tag} already exists, skipping release"
+            exit 0
+          fi
+
+          mkdir -p assets
+
+          # Package each module
+          echo "=== Packaging individual modules ==="
+          MODULE_LIST=""
+          for mod in zabbix_*/; do
+            mod="${mod%/}"
+            [ -f "${mod}/manifest.json" ] || continue
+            mod_ver=$(python3 -c "import json; print(json.load(open('${mod}/manifest.json'))['version'])")
+            echo "Packaging ${mod} v${mod_ver}..."
+            tar -czf "assets/${mod}-${mod_ver}.tar.gz" "${mod}"
+            ls -lh "assets/${mod}-${mod_ver}.tar.gz"
+            MODULE_LIST="${MODULE_LIST}- ${mod} - v${mod_ver}\n"
+          done
+
+          # Package entire project (all modules together)
+          echo "=== Packaging entire project ==="
+          tar -czf "assets/zabbix_modules-${VERSION}.tar.gz" \
+            --exclude=".git" \
+            --exclude=".github" \
+            --exclude="*.md" \
+            --exclude="*.csv" \
+            --exclude="images" \
+            zabbix_*/
+
+          echo "Packaged zabbix_modules-${VERSION}.tar.gz:"
+          ls -lh "assets/zabbix_modules-${VERSION}.tar.gz"
+
+          # Create release notes file
+          {
+            echo "## Zabbix Modules ${VERSION}"
+            echo ""
+            echo "### Included Modules"
+            echo ""
+            for mod in zabbix_*/; do
+              mod="${mod%/}"
+              if [ -f "${mod}/manifest.json" ]; then
+                mod_ver=$(python3 -c "import json; print(json.load(open('${mod}/manifest.json'))['version'])")
+                echo "- ${mod} - v${mod_ver}"
+              fi
+            done
+            echo ""
+            echo "### Assets"
+            echo ""
+            echo "- \`zabbix_modules-${VERSION}.tar.gz\` - 所有模块整体打包（All modules in one package）"
+            echo "- \`zabbix_<module>-<version>.tar.gz\` - 单个模块独立打包（Individual module packages）"
+            echo ""
+            echo "### Deployment"
+            echo ""
+            echo "#### 选项 A：部署所有模块（整体包）"
+            echo ""
+            echo "1. Download \`zabbix_modules-${VERSION}.tar.gz\` below"
+            echo "2. Upload to Zabbix server and extract:"
+            echo ""
+            echo '```bash'
+            echo "# Zabbix 6.0 / 7.0"
+            echo "tar -xzf zabbix_modules-${VERSION}.tar.gz -C /usr/share/zabbix/modules/"
+            echo ""
+            echo "# Zabbix 7.2+ / 7.4 / 8.0"
+            echo "tar -xzf zabbix_modules-${VERSION}.tar.gz -C /usr/share/zabbix/ui/modules/"
+            echo '```'
+            echo ""
+            echo "3. If using Zabbix 6.0, change manifest_version for all modules:"
+            echo '```bash'
+            echo "sed -i 's/\"manifest_version\": 2.0/\"manifest_version\": 1.0/' /usr/share/zabbix/modules/zabbix_*/manifest.json"
+            echo '```'
+            echo ""
+            echo "#### Option B: Deploy a single module"
+            echo ""
+            echo "1. Download the \`zabbix_<module>-<version>.tar.gz\` file for the module you want"
+            echo "2. Upload to Zabbix server and extract:"
+            echo ""
+            echo '```bash'
+            echo "# Zabbix 6.0 / 7.0"
+            echo "tar -xzf zabbix_<module>-<version>.tar.gz -C /usr/share/zabbix/modules/"
+            echo ""
+            echo "# Zabbix 7.2+ / 7.4 / 8.0"
+            echo "tar -xzf zabbix_<module>-<version>.tar.gz -C /usr/share/zabbix/ui/modules/"
+            echo '```'
+            echo ""
+            echo "3. If using Zabbix 6.0, change manifest_version:"
+            echo '```bash'
+            echo "sed -i 's/\"manifest_version\": 2.0/\"manifest_version\": 1.0/' /usr/share/zabbix/modules/zabbix_<module>/manifest.json"
+            echo '```'
+            echo ""
+            echo "### Enable modules in Zabbix Web"
+            echo ""
+            echo "1. Open Zabbix Web UI → Administration → General → Modules"
+            echo "2. Click **Scan directory** to detect new modules"
+            echo "3. Enable the modules you need"
+          } > release_notes.md
+
+          # Create single Release with all assets
+          echo "=== Creating release ${tag} with all assets ==="
+          gh release create "${tag}" \
+            assets/*.tar.gz \
+            --title "Zabbix Modules ${VERSION}" \
+            --notes-file release_notes.md \
+            --repo "${{ github.repository }}"
+
+          echo "=== Released ${tag} ==="
+          echo "Assets in release:"
+          gh release view "${tag}" --json assets --jq '.assets[].name' \
+            --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -195,9 +195,60 @@
 
 ## 安装说明
 
-### 安装模块
+### 方式一：下载 Releases 压缩包（适合生产部署，按需选择）
 
-这是最简单快捷的安装方式，一次性部署所有模块：
+Releases 页面提供两种压缩包，无需安装 git：
+
+- **整体打包压缩包**：`zabbix_modules-<版本号>.tar.gz`（包含所有模块，版本号格式：`模块数量.大版本.小版本`，如 `8.2.0`）
+- **单模块压缩包**：`zabbix_<模块名>-<版本号>.tar.gz`（按需下载单个模块）
+
+#### 选项 A：下载所有模块整体压缩包
+
+1. 前往 [Releases 页面](https://github.com/X-Mars/zabbix_modules/releases)，下载 `zabbix_modules-<版本号>.tar.gz` 文件（如 `zabbix_modules-8.2.0.tar.gz`）
+2. 上传到 Zabbix 服务器并解压到模块目录：
+
+```bash
+# Zabbix 6.0 / 7.0
+tar -xzf zabbix_modules-<版本号>.tar.gz -C /usr/share/zabbix/modules/
+
+# Zabbix 7.2+ / 7.4 / 8.0
+tar -xzf zabbix_modules-<版本号>.tar.gz -C /usr/share/zabbix/ui/modules/
+```
+
+3. **如果使用 Zabbix 6.0，修改所有模块的 manifest_version**
+
+```bash
+for mod in /usr/share/zabbix/modules/zabbix_*/; do
+  sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' ${mod}manifest.json
+done
+```
+
+如果使用 Zabbix 7.0+ 或 8.0+，则无需修改，保持默认值即可。
+
+#### 选项 B：下载单个模块
+
+1. 前往 [Releases 页面](https://github.com/X-Mars/zabbix_modules/releases)，下载所需模块的 `zabbix_<模块名>-<版本号>.tar.gz` 文件
+2. 上传到 Zabbix 服务器并解压到模块目录：
+
+```bash
+# Zabbix 6.0 / 7.0
+tar -xzf zabbix_<模块名>-<版本号>.tar.gz -C /usr/share/zabbix/modules/
+
+# Zabbix 7.2+ / 7.4 / 8.0
+tar -xzf zabbix_<模块名>-<版本号>.tar.gz -C /usr/share/zabbix/ui/modules/
+```
+
+3. **如果使用 Zabbix 6.0，修改 manifest_version**
+
+```bash
+sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' /usr/share/zabbix/modules/zabbix_<模块名>/manifest.json
+```
+
+如果使用 Zabbix 7.0+ 或 8.0+，则无需修改，保持默认值即可。
+
+### 方式二：git clone 直接部署（适合开发/跟踪更新）
+
+一次性部署所有模块：
 
 1. **Zabbix 6.0 / 7.0 部署方法**
 
@@ -205,7 +256,7 @@
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 ```
 
-2. **Zabbix 7.4 / 8.0 部署方法**
+2. **Zabbix 7.2+ / 7.4 / 8.0 部署方法**
 
 ```bash
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
@@ -213,31 +264,16 @@ git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modu
 
 3. **如果使用Zabbix 6.0，修改manifest_version**
 
+一键修改所有模块：
+
 ```bash
-cd /usr/share/zabbix/modules/
-# 修改 zabbix_reports 模块
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_reports/manifest.json
+sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' /usr/share/zabbix/modules/zabbix_*/manifest.json
+```
 
-# 修改 zabbix_cmdb 模块
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_cmdb/manifest.json
+单独修改某个模块（如 zabbix_reports）：
 
-# 修改 zabbix_graphtrees 模块
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_graphtrees/manifest.json
-
-# 修改 zabbix_rack 模块
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_rack/manifest.json
-
-# 修改 zabbix_snmp 模块
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_snmp/manifest.json
-
-# 修改 zabbix_jumpserver 模块
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_jumpserver/manifest.json
-
-# 修改 zabbix_im 模块
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_im/manifest.json
-
-# 修改 zabbix_clonehosts 模块
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_clonehosts/manifest.json
+```bash
+sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' /usr/share/zabbix/modules/zabbix_reports/manifest.json
 ```
 
 如果使用 Zabbix 7.0+ 或 8.0+，则无需修改，保持默认值即可。

--- a/README_en.md
+++ b/README_en.md
@@ -104,7 +104,58 @@ This repository contains a collection of independent Zabbix frontend modules tha
 
 ## Installation
 
-### Deploy all modules (recommended)
+### Option 1: Download Release packages (for production, choose what you need)
+
+The Releases page offers two types of packages — no git required:
+
+- **All-in-one package**: `zabbix_modules-<version>.tar.gz` (includes all modules; version format: `module_count.major.minor`, e.g., `8.2.0`)
+- **Single-module package**: `zabbix_<module>-<version>.tar.gz` (download only the modules you need)
+
+#### Option A: Download the all-in-one package
+
+1. Go to the [Releases page](https://github.com/X-Mars/zabbix_modules/releases) and download the `zabbix_modules-<version>.tar.gz` file (e.g., `zabbix_modules-8.2.0.tar.gz`).
+2. Upload to the Zabbix server and extract to the modules directory:
+
+   ```bash
+   # Zabbix 6.0 / 7.0
+   tar -xzf zabbix_modules-<version>.tar.gz -C /usr/share/zabbix/modules/
+
+   # Zabbix 7.2+ / 7.4 / 8.0
+   tar -xzf zabbix_modules-<version>.tar.gz -C /usr/share/zabbix/ui/modules/
+   ```
+
+3. If you run Zabbix 6.0, change `manifest_version` for every module:
+
+   ```bash
+   for mod in /usr/share/zabbix/modules/zabbix_*/; do
+     sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' ${mod}manifest.json
+   done
+   ```
+
+   For Zabbix 7.0+ / 8.0+, no change is required.
+
+#### Option B: Download a single module
+
+1. Go to the [Releases page](https://github.com/X-Mars/zabbix_modules/releases) and download the `zabbix_<module>-<version>.tar.gz` file for the module you want.
+2. Upload to the Zabbix server and extract to the modules directory:
+
+   ```bash
+   # Zabbix 6.0 / 7.0
+   tar -xzf zabbix_<module>-<version>.tar.gz -C /usr/share/zabbix/modules/
+
+   # Zabbix 7.2+ / 7.4 / 8.0
+   tar -xzf zabbix_<module>-<version>.tar.gz -C /usr/share/zabbix/ui/modules/
+   ```
+
+3. If you run Zabbix 6.0, change `manifest_version`:
+
+   ```bash
+   sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' /usr/share/zabbix/modules/zabbix_<module>/manifest.json
+   ```
+
+   For Zabbix 7.0+ / 8.0+, no change is required.
+
+### Option 2: Deploy all modules via git clone (for development / tracking updates)
 
 1. For Zabbix 6.0 / 7.0:
 
@@ -112,7 +163,7 @@ This repository contains a collection of independent Zabbix frontend modules tha
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 ```
 
-2. For Zabbix 7.4 / 8.0:
+2. For Zabbix 7.2+ / 7.4 / 8.0:
 
 ```bash
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
@@ -120,16 +171,16 @@ git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modu
 
 3. If you run Zabbix 6.0, change `manifest_version` for each module:
 
+One-liner for all modules:
+
 ```bash
-cd /usr/share/zabbix/modules/
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_reports/manifest.json
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_cmdb/manifest.json
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_graphtrees/manifest.json
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_rack/manifest.json
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_snmp/manifest.json
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_jumpserver/manifest.json
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_im/manifest.json
-sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' zabbix_clonehosts/manifest.json
+sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' /usr/share/zabbix/modules/zabbix_*/manifest.json
+```
+
+For a single module (e.g., zabbix_reports):
+
+```bash
+sed -i 's/"manifest_version": 2.0/"manifest_version": 1.0/' /usr/share/zabbix/modules/zabbix_reports/manifest.json
 ```
 
 For Zabbix 7.0+ / 8.0+, no change is required.

--- a/zabbix_clonehosts/README.md
+++ b/zabbix_clonehosts/README.md
@@ -58,7 +58,7 @@
 # Zabbix 6.0 / 7.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 部署方法
+# Zabbix 7.2+ / 7.4 / 8.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_clonehosts/README_en.md
+++ b/zabbix_clonehosts/README_en.md
@@ -47,7 +47,7 @@ Zabbix Clonehosts is a frontend module for Zabbix that batch-clones and imports 
 # For Zabbix 6.0 / 7.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# For Zabbix 7.4 / 8.0 deployment
+# For Zabbix 7.2+ / 7.4 / 8.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_clonehosts/manifest.json
+++ b/zabbix_clonehosts/manifest.json
@@ -5,7 +5,7 @@
     "author": "火星小刘/先龍",
     "url": "https://github.com/X-Mars/zabbix_modules",
     "namespace": "ZabbixClonehosts",
-    "version": "1.2",
+    "version": "1.2.0",
     "description": "Batch clone/import hosts based on an existing monitored host. Supports CSV/online table entry, preview with conflict detection, auto-creation of host groups, existence status indicators, and progress feedback. Compatible with Zabbix 6.0/6.4/7.x. Auto-syncs language with Zabbix system settings (Chinese/English).",
     "actions": {
         "clonehosts": {

--- a/zabbix_cmdb/README.md
+++ b/zabbix_cmdb/README.md
@@ -50,7 +50,7 @@
 # Zabbix 6.0 / 7.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 部署方法
+# Zabbix 7.2+ / 7.4 / 8.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_cmdb/README_en.md
+++ b/zabbix_cmdb/README_en.md
@@ -50,7 +50,7 @@ This is a Zabbix frontend module that provides Configuration Management Database
 # Zabbix 6.0 / 7.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 deployment
+# Zabbix 7.2+ / 7.4 / 8.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_graphtrees/README.md
+++ b/zabbix_graphtrees/README.md
@@ -48,7 +48,7 @@
 # Zabbix 6.0 / 7.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 部署方法
+# Zabbix 7.2+ / 7.4 / 8.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_graphtrees/README_en.md
+++ b/zabbix_graphtrees/README_en.md
@@ -47,7 +47,7 @@ This is a Zabbix frontend module that provides tree-structured resource browsing
 # Zabbix 6.0 / 7.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 deployment
+# Zabbix 7.2+ / 7.4 / 8.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_im/README.md
+++ b/zabbix_im/README.md
@@ -43,7 +43,7 @@
 # Zabbix 6.0 / 7.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 部署方法
+# Zabbix 7.2+ / 7.4 / 8.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_im/README_en.md
+++ b/zabbix_im/README_en.md
@@ -43,7 +43,7 @@ The module adds an **IM Sync Assistant** submenu under the **Users** menu in Zab
 # Zabbix 6.0 / 7.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 deployment
+# Zabbix 7.2+ / 7.4 / 8.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_jumpserver/README.md
+++ b/zabbix_jumpserver/README.md
@@ -100,7 +100,7 @@
 # Zabbix 6.0 / 7.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 部署方法
+# Zabbix 7.2+ / 7.4 / 8.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_jumpserver/README_en.md
+++ b/zabbix_jumpserver/README_en.md
@@ -100,7 +100,7 @@ Useful when assets already exist in JumpServer but Zabbix hosts do not yet have 
 # Zabbix 6.0 / 7.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 deployment
+# Zabbix 7.2+ / 7.4 / 8.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_rack/README.md
+++ b/zabbix_rack/README.md
@@ -66,7 +66,7 @@
 # Zabbix 6.0 / 7.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 部署方法
+# Zabbix 7.2+ / 7.4 / 8.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_rack/README_en.md
+++ b/zabbix_rack/README_en.md
@@ -66,7 +66,7 @@ This is a Zabbix frontend module for data center rack visualization and host pla
 # Zabbix 6.0 / 7.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 deployment
+# Zabbix 7.2+ / 7.4 / 8.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_reports/README.md
+++ b/zabbix_reports/README.md
@@ -47,7 +47,7 @@
 # Zabbix 6.0 / 7.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 部署方法
+# Zabbix 7.2+ / 7.4 / 8.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_reports/README_en.md
+++ b/zabbix_reports/README_en.md
@@ -47,7 +47,7 @@ Zabbix Reports is a frontend module for Zabbix that generates daily, weekly, and
 # For Zabbix 6.0 / 7.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# For Zabbix 7.4 / 8.0 deployment
+# For Zabbix 7.2+ / 7.4 / 8.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_snmp/README.md
+++ b/zabbix_snmp/README.md
@@ -56,7 +56,7 @@
 # Zabbix 6.0 / 7.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 部署方法
+# Zabbix 7.2+ / 7.4 / 8.0 部署方法
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 

--- a/zabbix_snmp/README_en.md
+++ b/zabbix_snmp/README_en.md
@@ -56,7 +56,7 @@ This is a Zabbix frontend module that provides an SNMP assistant. It adds an **S
 # Zabbix 6.0 / 7.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/modules/
 
-# Zabbix 7.4 / 8.0 deployment
+# Zabbix 7.2+ / 7.4 / 8.0 deployment
 git clone https://github.com/X-Mars/zabbix_modules.git /usr/share/zabbix/ui/modules/
 ```
 


### PR DESCRIPTION
Summary
This PR adds automated release workflow and Zabbix 7.2+ path compatibility for the zabbix_modules project.

Changes Made
1. 🤖 Automated Release Workflow
New file: .github/workflows/release.yml

Creates a single Release with multiple Assets:
zabbix_modules-{version}.tar.gz - All modules in one package
zabbix_{module}-{version}.tar.gz - Individual module packages
Version format: {module_count}.{major}.{minor} (e.g., 8.2.0 for 8 modules, 2nd major release)
Auto-detects module version bumps in manifest.json
Supports manual trigger via workflow_dispatch
Auto-generates release notes with deployment instructions
2. 📝 Documentation Updates (All READMEs)
Updated: README.md, README_en.md, and all 8 module READMEs

Zabbix 7.2+ Path Compatibility:
Zabbix 6.0 / 7.0: /usr/share/zabbix/modules/
Zabbix 7.2+ / 7.4 / 8.0: /usr/share/zabbix/ui/modules/
Zabbix 6.0 manifest_version Fix: Added one-liner script to change manifest_version from 2.0 to 1.0
Installation Options Reordered: All-in-one package first, then single module
Version Format Documentation: Added explanation for module_count.major.minor version format
3. 🔢 Version Standardization
Updated: zabbix_clonehosts/manifest.json

Bumped zabbix_clonehosts version from 1.2 to 1.2.0 for semver 3-digit consistency
Files Changed
Type	Files	Changes
New	.github/workflows/release.yml	+202 lines
Modified	README.md / README_en.md	+84/+73 lines
Modified	zabbix_clonehosts/manifest.json	Version bump
Modified	All 8 module READMEs	Path compatibility updates
Testing
✅ GitHub Actions workflow tested successfully (Release v8.2.0 created with 11 Assets)
✅ All modules packaged correctly (all-in-one + individual packages)
✅ Release notes auto-generated with deployment instructions