### PR TITLE
feat: zabbix_clonehosts v1.3.0 - real-time progress stats, Zabbix 6.0…

### DIFF
--- a/zabbix_clonehosts/LangHelper.php
+++ b/zabbix_clonehosts/LangHelper.php
@@ -464,6 +464,18 @@ class LangHelper {
 			'en_GB' => 'Import Progress',
 			'zh_CN' => '导入进度'
 		],
+		'import.status_success' => [
+			'en_GB' => 'Success:',
+			'zh_CN' => '成功：'
+		],
+		'import.status_failed' => [
+			'en_GB' => 'Failed:',
+			'zh_CN' => '失败：'
+		],
+		'import.status_pending' => [
+			'en_GB' => 'Pending:',
+			'zh_CN' => '待处理：'
+		],
 		'import.importing' => [
 			'en_GB' => 'Importing...',
 			'zh_CN' => '导入中...'

--- a/zabbix_clonehosts/Module.php
+++ b/zabbix_clonehosts/Module.php
@@ -23,6 +23,7 @@ namespace Modules\ZabbixClonehosts;
 use APP,
 	CMenu,
 	CMenuItem;
+use Modules\ZabbixClonehosts\CompatHelper;
 
 /**
  * Trait containing the module initialization logic shared across Zabbix versions.
@@ -32,8 +33,13 @@ trait ModuleInitTrait {
 	public function init(): void {
 		$menu_label = LangHelper::t('menu.clonehosts');
 
+		// Zabbix menu structure differs by version:
+		// - Zabbix 6.0: Configuration → Hosts
+		// - Zabbix 6.4+: Data collection → Hosts
+		$main_menu_name = CompatHelper::isZabbix60() ? _('Configuration') : _('Data collection');
+
 		APP::Component()->get('menu.main')
-			->findOrAdd(_('Data collection'))
+			->findOrAdd($main_menu_name)
 			->getSubmenu()
 			->insertAfter(_('Hosts'),
 				(new CMenuItem($menu_label))->setAction('clonehosts')

--- a/zabbix_clonehosts/actions/ClonehostsImport.php
+++ b/zabbix_clonehosts/actions/ClonehostsImport.php
@@ -338,7 +338,8 @@ class ClonehostsImport extends CController {
 				$result['success'] = true;
 				$result['hostid'] = $created['hostids'][0];
 			} else {
-				$result['error'] = LangHelper::t('err.unknown_api_response');
+				$result['error'] = LangHelper::t('err.unknown_api_response')
+					. ': ' . json_encode($created, JSON_UNESCAPED_UNICODE);
 			}
 		} catch (\Exception $e) {
 			$result['error'] = $e->getMessage();

--- a/zabbix_clonehosts/assets/css/clonehosts.css
+++ b/zabbix_clonehosts/assets/css/clonehosts.css
@@ -889,6 +889,32 @@
 	min-width: 80px;
 }
 
+.progress-stats {
+	display: flex;
+	gap: 20px;
+	padding: 10px 15px;
+	background: #f4f6f8;
+	border-radius: 3px;
+	margin-bottom: 15px;
+}
+
+.progress-stat {
+	font-size: 13px;
+	font-weight: 600;
+}
+
+.progress-success {
+	color: #4caf50;
+}
+
+.progress-failed {
+	color: #f44336;
+}
+
+.progress-pending {
+	color: #768390;
+}
+
 /* ===== Results ===== */
 .results-summary {
 	display: flex;

--- a/zabbix_clonehosts/assets/js/clonehosts.preview.js.php
+++ b/zabbix_clonehosts/assets/js/clonehosts.preview.js.php
@@ -181,6 +181,9 @@
 		var percent = Math.round((processedCount / importQueue.length) * 100);
 		$('#progress-bar').css('width', percent + '%');
 		$('#progress-text').text(processedCount + ' / ' + importQueue.length);
+		$('#progress-success').text(successCount);
+		$('#progress-failed').text(failedCount);
+		$('#progress-pending').text(importQueue.length - processedCount);
 		$('#success-count').text(successCount);
 		$('#failed-count').text(failedCount);
 	}

--- a/zabbix_clonehosts/manifest.json
+++ b/zabbix_clonehosts/manifest.json
@@ -5,7 +5,7 @@
     "author": "火星小刘/先龍",
     "url": "https://github.com/X-Mars/zabbix_modules",
     "namespace": "ZabbixClonehosts",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Batch clone/import hosts based on an existing monitored host. Supports CSV/online table entry, preview with conflict detection, auto-creation of host groups, existence status indicators, and progress feedback. Compatible with Zabbix 6.0/6.4/7.x. Auto-syncs language with Zabbix system settings (Chinese/English).",
     "actions": {
         "clonehosts": {

--- a/zabbix_clonehosts/views/clonehosts.php
+++ b/zabbix_clonehosts/views/clonehosts.php
@@ -24,6 +24,12 @@
  */
 
 use Modules\ZabbixClonehosts\LangHelper;
+use Modules\ZabbixClonehosts\CompatHelper;
+
+// Zabbix 6.0 does not auto-load assets declared in manifest.json.
+// Detect once and emit manual <link>/<script> tags at the right places.
+$need_manual_assets = CompatHelper::isZabbix60();
+$module_asset_base = 'modules/zabbix_clonehosts/assets';
 
 // Build group and template name lists for JavaScript reference.
 $group_names = [];
@@ -58,6 +64,10 @@ foreach ($data['host_groups'] as $group) {
 	];
 }
 ?>
+
+<?php if ($need_manual_assets): ?>
+<link rel="stylesheet" href="<?= $module_asset_base ?>/css/clonehosts.css?v=<?= rawurlencode($data['module_version'] ?? '1.2.0') ?>">
+<?php endif; ?>
 
 <div class="clonehosts-page">
 	<!-- Step 1: Source Host Selection -->
@@ -209,3 +219,7 @@ foreach ($data['host_groups'] as $group) {
 		returnHostData: <?= json_encode($data['return_host_data'] ?? []) ?>
 	};
 </script>
+
+<?php if ($need_manual_assets): ?>
+<script type="text/javascript" src="<?= $module_asset_base ?>/js/clonehosts.js.php?v=<?= rawurlencode($data['module_version'] ?? '1.2.0') ?>"></script>
+<?php endif; ?>

--- a/zabbix_clonehosts/views/clonehosts.preview.php
+++ b/zabbix_clonehosts/views/clonehosts.preview.php
@@ -24,6 +24,11 @@
  */
 
 use Modules\ZabbixClonehosts\LangHelper;
+use Modules\ZabbixClonehosts\CompatHelper;
+
+// Zabbix 6.0 does not auto-load assets declared in manifest.json.
+$need_manual_assets = CompatHelper::isZabbix60();
+$module_asset_base = 'modules/zabbix_clonehosts/assets';
 
 $source_host = $data['source_host'];
 $host_data = $data['host_data'];
@@ -88,6 +93,10 @@ foreach ($host_data as $item) {
 	];
 }
 ?>
+
+<?php if ($need_manual_assets): ?>
+<link rel="stylesheet" href="<?= $module_asset_base ?>/css/clonehosts.css?v=<?= rawurlencode($data['module_version'] ?? '1.2.0') ?>">
+<?php endif; ?>
 
 <div class="clonehosts-page">
 	<!-- Source Host Summary -->
@@ -276,6 +285,12 @@ foreach ($host_data as $item) {
 			<span id="progress-text" class="progress-text">0 / <?= $total_count ?></span>
 		</div>
 
+		<div id="progress-stats" class="progress-stats">
+			<span class="progress-stat progress-success"><?= LangHelper::t('import.status_success') ?> <span id="progress-success">0</span></span>
+			<span class="progress-stat progress-failed"><?= LangHelper::t('import.status_failed') ?> <span id="progress-failed">0</span></span>
+			<span class="progress-stat progress-pending"><?= LangHelper::t('import.status_pending') ?> <span id="progress-pending"><?= $total_count ?></span></span>
+		</div>
+
 		<div id="import-results-section" style="display:none;">
 			<h3><?= LangHelper::t('import.results_title') ?></h3>
 			<div class="results-summary">
@@ -312,3 +327,7 @@ foreach ($host_data as $item) {
 		lang: <?= json_encode(LangHelper::getAllForJs()) ?>
 	};
 </script>
+
+<?php if ($need_manual_assets): ?>
+<script type="text/javascript" src="<?= $module_asset_base ?>/js/clonehosts.preview.js.php?v=<?= rawurlencode($data['module_version'] ?? '1.2.0') ?>"></script>
+<?php endif; ?>


### PR DESCRIPTION
修改文件（8个）：

文件	                         修改内容
LangHelper.php	 添加进度状态语言字符串
Module.php	        菜单位置修正（6.0/6.4+）
ClonehostsImport.php	API 错误详情优化
clonehosts.css	  进度统计样式
clonehosts.preview.js.php	  实时更新统计
manifest.json	     版本号 1.2.0 → 1.3.0
clonehosts.php	Zabbix 6.0 JS/CSS 手动加载
clonehosts.preview.php	进度统计区域 + 手动加载